### PR TITLE
Add SwiftUI iOS rolling 10-day z-score calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,431 @@
+<!doctype html>
+<html lang="zh-Hans">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>滚动 10 日 z-score 计算器</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f7fb;
+        --card: #ffffff;
+        --text: #1a1a1a;
+        --muted: #60646b;
+        --border: #e3e6ee;
+        --accent: #1e4fa3;
+        --accent-soft: rgba(30, 79, 163, 0.1);
+        --shadow: 0 12px 30px rgba(32, 37, 57, 0.08);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+      }
+
+      .page {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 48px 24px 72px;
+      }
+
+      .hero {
+        margin-bottom: 32px;
+      }
+
+      .eyebrow {
+        color: var(--accent);
+        font-weight: 600;
+        margin: 0 0 8px;
+      }
+
+      h1 {
+        margin: 0 0 16px;
+        font-size: clamp(2rem, 2.6vw, 2.8rem);
+      }
+
+      .subtitle {
+        color: var(--muted);
+        max-width: 720px;
+        margin: 0;
+      }
+
+      .formula-card {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        padding: 24px;
+        box-shadow: var(--shadow);
+      }
+
+      .formula-card h2 {
+        font-size: 1.1rem;
+        margin: 0 0 12px;
+      }
+
+      .formula {
+        font-size: 1.1rem;
+        margin: 6px 0;
+        color: #111827;
+      }
+
+      .frac {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: center;
+        font-size: 0.9em;
+        line-height: 1;
+        margin: 0 2px;
+      }
+
+      .frac span:first-child {
+        border-bottom: 1px solid currentColor;
+        padding: 0 4px 2px;
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: flex-end;
+        margin: 28px 0 16px;
+      }
+
+      .control label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 6px;
+      }
+
+      .control select {
+        padding: 8px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: var(--card);
+      }
+
+      .ghost {
+        border: 1px solid var(--border);
+        background: transparent;
+        padding: 10px 16px;
+        border-radius: 10px;
+        cursor: pointer;
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      .ghost:hover {
+        background: var(--accent-soft);
+      }
+
+      .table-card {
+        background: var(--card);
+        border-radius: 18px;
+        border: 1px solid var(--border);
+        overflow: hidden;
+        box-shadow: var(--shadow);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.98rem;
+      }
+
+      thead {
+        background: #f1f4fb;
+      }
+
+      th,
+      td {
+        padding: 12px 14px;
+        text-align: left;
+        border-bottom: 1px solid var(--border);
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      input[type="number"] {
+        width: 100%;
+        padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: #fff;
+      }
+
+      .dt-cell {
+        font-weight: 600;
+        color: var(--accent);
+      }
+
+      .results {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        margin: 28px 0 20px;
+      }
+
+      .result-card {
+        background: var(--card);
+        border-radius: 16px;
+        padding: 18px;
+        border: 1px solid var(--border);
+        box-shadow: var(--shadow);
+      }
+
+      .result-card.highlight {
+        border-color: var(--accent);
+        background: #f2f6ff;
+      }
+
+      .label {
+        color: var(--muted);
+        margin: 0 0 6px;
+      }
+
+      .value {
+        font-size: 1.6rem;
+        font-weight: 700;
+        margin: 0;
+      }
+
+      .notes {
+        background: var(--card);
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        padding: 18px 22px;
+        box-shadow: var(--shadow);
+      }
+
+      .notes h2 {
+        margin-top: 0;
+      }
+
+      .notes ul {
+        margin: 0;
+        padding-left: 20px;
+        color: var(--muted);
+      }
+
+      @media (max-width: 720px) {
+        th,
+        td {
+          padding: 10px;
+        }
+
+        .formula {
+          font-size: 1rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <header class="hero">
+        <p class="eyebrow">一、滚动 10 日 z-score 是如何精确计算的？</p>
+        <h1>滚动 10 日 z-score 计算器</h1>
+        <p class="subtitle">
+          输入最近 10 天的 VIX3M 与 VIX1M，计算每日期限结构价差，以及 10 日滚动均值、标准差与 z-score。
+        </p>
+      </header>
+
+      <section class="formula-card">
+        <div>
+          <h2>定义每日期限结构价差</h2>
+          <p class="formula">d<sub>t</sub> = VIX3M<sub>t</sub> − VIX1M<sub>t</sub></p>
+        </div>
+        <div>
+          <h2>计算 10 日滚动均值与标准差</h2>
+          <p class="formula">
+            μ<sub>t</sub> = <span class="frac"><span>1</span><span>10</span></span>
+            ∑<sub>i=0</sub><sup>9</sup> d<sub>t-i</sub>
+          </p>
+          <p class="formula">
+            s<sub>t</sub> =
+            √(
+            <span class="frac"><span>1</span><span>9</span></span>
+            ∑<sub>i=0</sub><sup>9</sup> (d<sub>t-i</sub> − μ<sub>t</sub>)² )
+          </p>
+        </div>
+        <div>
+          <h2>最终得到 z-score</h2>
+          <p class="formula">z<sub>t</sub> = (d<sub>t</sub> − μ<sub>t</sub>) / s<sub>t</sub></p>
+        </div>
+      </section>
+
+      <section class="controls">
+        <div class="control">
+          <label for="std-method">标准差口径</label>
+          <select id="std-method">
+            <option value="sample" selected>样本标准差（1/9，STDEV.S）</option>
+            <option value="population">总体标准差（1/10）</option>
+          </select>
+        </div>
+        <button class="ghost" id="fill-sample" type="button">填充示例数据</button>
+        <button class="ghost" id="clear-all" type="button">清空数据</button>
+      </section>
+
+      <section class="table-card">
+        <table>
+          <thead>
+            <tr>
+              <th>日期</th>
+              <th>VIX3M</th>
+              <th>VIX1M</th>
+              <th>d<sub>t</sub> = VIX3M − VIX1M</th>
+            </tr>
+          </thead>
+          <tbody id="data-rows"></tbody>
+        </table>
+      </section>
+
+      <section class="results">
+        <div class="result-card">
+          <p class="label">10 日滚动均值 μ<sub>t</sub></p>
+          <p class="value" id="mean-value">—</p>
+        </div>
+        <div class="result-card">
+          <p class="label">10 日滚动标准差 s<sub>t</sub></p>
+          <p class="value" id="std-value">—</p>
+        </div>
+        <div class="result-card highlight">
+          <p class="label">z-score z<sub>t</sub></p>
+          <p class="value" id="zscore-value">—</p>
+        </div>
+      </section>
+
+      <section class="notes">
+        <h2>解释</h2>
+        <ul>
+          <li>使用 1/9 为常见的样本标准差做法（Excel 的 STDEV.S）。</li>
+          <li>如需总体标准差，可切换至 1/10，只要前后一致即可。</li>
+          <li>当 z-score 为 −2，表示当前期限价差比最近 10 日均值低 2 个标准差。</li>
+        </ul>
+      </section>
+    </main>
+    <script>
+      const rowsContainer = document.getElementById("data-rows");
+      const meanValue = document.getElementById("mean-value");
+      const stdValue = document.getElementById("std-value");
+      const zscoreValue = document.getElementById("zscore-value");
+      const stdMethod = document.getElementById("std-method");
+      const fillSample = document.getElementById("fill-sample");
+      const clearAll = document.getElementById("clear-all");
+
+      const TOTAL_DAYS = 10;
+
+      const buildRows = () => {
+        rowsContainer.innerHTML = "";
+        for (let i = TOTAL_DAYS; i >= 1; i -= 1) {
+          const row = document.createElement("tr");
+          row.innerHTML = `
+            <td>第 ${i} 天</td>
+            <td><input type="number" step="0.01" inputmode="decimal" placeholder="VIX3M" /></td>
+            <td><input type="number" step="0.01" inputmode="decimal" placeholder="VIX1M" /></td>
+            <td class="dt-cell" data-dt>—</td>
+          `;
+          rowsContainer.appendChild(row);
+        }
+      };
+
+      const parseValue = (input) => {
+        const value = Number.parseFloat(input.value);
+        return Number.isFinite(value) ? value : null;
+      };
+
+      const formatNumber = (value) => {
+        if (!Number.isFinite(value)) {
+          return "—";
+        }
+        return value.toFixed(4);
+      };
+
+      const updateResults = () => {
+        const rows = Array.from(rowsContainer.querySelectorAll("tr"));
+        const diffs = rows.map((row) => {
+          const inputs = row.querySelectorAll("input");
+          const vix3m = parseValue(inputs[0]);
+          const vix1m = parseValue(inputs[1]);
+          const dtCell = row.querySelector("[data-dt]");
+
+          if (vix3m === null || vix1m === null) {
+            dtCell.textContent = "—";
+            return null;
+          }
+
+          const diff = vix3m - vix1m;
+          dtCell.textContent = diff.toFixed(4);
+          return diff;
+        });
+
+        if (diffs.some((value) => value === null)) {
+          meanValue.textContent = "—";
+          stdValue.textContent = "—";
+          zscoreValue.textContent = "—";
+          return;
+        }
+
+        const values = diffs;
+        const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+        const denominator = stdMethod.value === "population" ? values.length : values.length - 1;
+        const variance =
+          values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / denominator;
+        const std = Math.sqrt(variance);
+        const latest = values[0];
+        const zscore = std === 0 ? null : (latest - mean) / std;
+
+        meanValue.textContent = formatNumber(mean);
+        stdValue.textContent = formatNumber(std);
+        zscoreValue.textContent = formatNumber(zscore);
+      };
+
+      const sampleData = [
+        [17.6, 15.1],
+        [17.2, 15.0],
+        [18.1, 15.4],
+        [17.9, 15.6],
+        [18.4, 15.8],
+        [18.0, 16.0],
+        [17.7, 15.9],
+        [17.5, 15.5],
+        [17.3, 15.2],
+        [17.1, 15.3],
+      ];
+
+      buildRows();
+
+      rowsContainer.addEventListener("input", updateResults);
+      stdMethod.addEventListener("change", updateResults);
+
+      fillSample.addEventListener("click", () => {
+        const rows = Array.from(rowsContainer.querySelectorAll("tr"));
+        rows.forEach((row, index) => {
+          const inputs = row.querySelectorAll("input");
+          const [vix3m, vix1m] = sampleData[index];
+          inputs[0].value = vix3m;
+          inputs[1].value = vix1m;
+        });
+        updateResults();
+      });
+
+      clearAll.addEventListener("click", () => {
+        rowsContainer.querySelectorAll("input").forEach((input) => {
+          input.value = "";
+        });
+        updateResults();
+      });
+
+      updateResults();
+    </script>
+  </body>
+</html>

--- a/ios_zscore_calculator.swift
+++ b/ios_zscore_calculator.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+
+struct ZScoreCalculatorView: View {
+    @State private var vix3M: [String] = Array(repeating: "", count: 10)
+    @State private var vix1M: [String] = Array(repeating: "", count: 10)
+    @State private var usePopulationStd = false
+
+    private var diffs: [Double?] {
+        zip(vix3M, vix1M).map { vix3, vix1 in
+            guard let v3 = Double(vix3), let v1 = Double(vix1) else {
+                return nil
+            }
+            return v3 - v1
+        }
+    }
+
+    private var mean: Double? {
+        let values = diffs.compactMap { $0 }
+        guard values.count == 10 else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    private var std: Double? {
+        let values = diffs.compactMap { $0 }
+        guard let mean, values.count == 10 else { return nil }
+        let denominator = usePopulationStd ? Double(values.count) : Double(values.count - 1)
+        let variance = values.reduce(0) { $0 + pow($1 - mean, 2) } / denominator
+        return sqrt(variance)
+    }
+
+    private var zScore: Double? {
+        guard let mean, let std, std > 0, let latest = diffs.first ?? nil else { return nil }
+        return (latest - mean) / std
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("一、滚动 10 日 z-score 是如何精确计算的？")
+                            .font(.headline)
+                            .foregroundColor(.blue)
+                        Text("滚动 10 日 z-score 计算器")
+                            .font(.title)
+                            .bold()
+                        Text("输入最近 10 天的 VIX3M 与 VIX1M，计算每日期限结构价差，以及 10 日滚动均值、标准差与 z-score。")
+                            .foregroundColor(.secondary)
+                    }
+
+                    formulaCard
+
+                    Toggle(isOn: $usePopulationStd) {
+                        Text(usePopulationStd ? "总体标准差（1/10）" : "样本标准差（1/9，STDEV.S）")
+                            .fontWeight(.semibold)
+                    }
+                    .toggleStyle(SwitchToggleStyle(tint: .blue))
+
+                    inputTable
+
+                    resultsCard
+
+                    explanationCard
+                }
+                .padding()
+            }
+            .navigationTitle("z-score 计算器")
+        }
+    }
+
+    private var formulaCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("定义每日期限结构价差")
+                .font(.headline)
+            Text("dₜ = VIX3Mₜ − VIX1Mₜ")
+                .font(.title3)
+
+            Text("计算 10 日滚动均值与标准差")
+                .font(.headline)
+            Text("μₜ = (1/10) Σᵢ₌₀⁹ dₜ₋ᵢ")
+            Text("sₜ = √( (1/9) Σᵢ₌₀⁹ (dₜ₋ᵢ − μₜ)² )")
+
+            Text("最终得到 z-score")
+                .font(.headline)
+            Text("zₜ = (dₜ − μₜ) / sₜ")
+                .font(.title3)
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+        .shadow(radius: 4, x: 0, y: 2)
+    }
+
+    private var inputTable: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("最近 10 天输入")
+                .font(.headline)
+            ForEach(0..<10, id: \.self) { index in
+                HStack(spacing: 12) {
+                    Text("第 \(10 - index) 天")
+                        .frame(width: 80, alignment: .leading)
+                    TextField("VIX3M", text: $vix3M[index])
+                        .keyboardType(.decimalPad)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    TextField("VIX1M", text: $vix1M[index])
+                        .keyboardType(.decimalPad)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    Text(diffText(for: index))
+                        .frame(width: 80, alignment: .trailing)
+                        .foregroundColor(.blue)
+                }
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+        .shadow(radius: 4, x: 0, y: 2)
+    }
+
+    private func diffText(for index: Int) -> String {
+        guard let diff = diffs[index] else { return "—" }
+        return String(format: "%.4f", diff)
+    }
+
+    private var resultsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("结果")
+                .font(.headline)
+            HStack {
+                resultBlock(title: "滚动均值 μₜ", value: mean)
+                resultBlock(title: "滚动标准差 sₜ", value: std)
+                resultBlock(title: "z-score zₜ", value: zScore)
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+        .shadow(radius: 4, x: 0, y: 2)
+    }
+
+    private func resultBlock(title: String, value: Double?) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text(formatted(value))
+                .font(.title3)
+                .fontWeight(.bold)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func formatted(_ value: Double?) -> String {
+        guard let value else { return "—" }
+        return String(format: "%.4f", value)
+    }
+
+    private var explanationCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("解释")
+                .font(.headline)
+            Text("• 使用 1/9 是常见的样本标准差做法（Excel 的 STDEV.S）。")
+            Text("• 有些人用 1/10（总体标准差），只要前后一致即可。")
+            Text("• 例如：zₜ = −2 表示当前期限价差比最近 10 日均值低 2 个标准差。")
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .cornerRadius(16)
+        .shadow(radius: 4, x: 0, y: 2)
+    }
+}
+
+@main
+struct ZScoreCalculatorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ZScoreCalculatorView()
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a native iOS implementation of the rolling 10-day z-score calculator to match the existing browser-first single-file tool.
- Allow users to enter the latest 10 days of `VIX3M` / `VIX1M` and compute per-day term-structure spreads, the 10-day rolling mean, standard deviation (sample vs population), and z-score.
- Keep the UI simple and self-contained so the calculator can run on-device and mirror the explanatory text and controls from the reference image.

### Description
- Add `ios_zscore_calculator.swift`, which provides a `ZScoreCalculatorView` and `@main` app entry that exposes 10 input rows, computes `diffs`, `mean`, `std` (toggleable `usePopulationStd`), and `zScore`, and formats outputs for display.
- Include UI elements in the SwiftUI view for the standard-deviation toggle, per-row `TextField` inputs, computed `d_t` cells, and result blocks for μₜ, sₜ, and zₜ.
- Ship a single-file web equivalent `index.html` with inlined CSS/JS that implements the same 10-day calculator, `fill-sample` / `clear-all` controls, and computation logic for parity with the native app.

### Testing
- The browser single-file `index.html` was exercised by serving locally with `python -m http.server` and a Playwright script was used to open the page and capture a screenshot, which completed successfully.
- The SwiftUI file `ios_zscore_calculator.swift` is a static app file and was not executed in automated tests.
- No automated unit tests were added for the native SwiftUI implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608351b9f8832aa5cb1baf7c782f7a)