### PR TITLE
Add delta-quote volatility surface plotter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,60 @@ This repository will get you started with building a quote bot in Python. It's m
 When complete, you'll be able to grab random quotes from the command line, like this:
 
 > **$** python get-quote.py
-> 
+>
 > Keep it logically awesome
-> 
+>
 > **$** python get-quote.py
-> 
+>
 > Speak like a human
 
 ## Start the Tutorial
 
 You can find your next step in [this repo's issues](../../issues/)!
+
+## FX volatility smile helper
+
+`vol_smile.py` generates a visual volatility smile curve from standard 10Δ/25Δ risk reversals and butterflies, plus an ATM volatility. It outputs the 10Δ/25Δ strikes and vols, and saves a plot to an image file.
+
+Example:
+
+```bash
+python vol_smile.py \
+  --atm 0.12 \
+  --rr-10 -0.02 \
+  --rr-25 -0.01 \
+  --bf-10 0.002 \
+  --bf-25 0.001 \
+  --forward 1.085 \
+  --maturity 0.5 \
+  --rd 0.03 \
+  --rf 0.01 \
+  --delta-convention spot \
+  --output smile.png
+```
+
+Use `--premium-adjusted` to switch to premium-adjusted delta.
+
+## FX volatility surface helper
+
+`vol_surface.py` generates a 3D volatility surface from spot and delta-based call/put vols (50Δ/25Δ/10Δ). It interpolates vols across deltas, derives strikes from the chosen delta convention, and renders a single-maturity surface.
+
+Example:
+
+```bash
+python vol_surface.py \
+  --spot 1.085 \
+  --maturity 0.5 \
+  --rd 0.03 \
+  --rf 0.01 \
+  --vol-50c 0.12 \
+  --vol-50p 0.12 \
+  --vol-25c 0.125 \
+  --vol-25p 0.118 \
+  --vol-10c 0.135 \
+  --vol-10p 0.115 \
+  --delta-convention spot \
+  --output surface.png
+```
+
+Use `--premium-adjusted` to switch to premium-adjusted delta.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ python vol_surface.py \
 ```
 
 Use `--premium-adjusted` to switch to premium-adjusted delta.
+
+Both helpers save PNG images to the local filesystem. You can transfer the generated image (for example, `smile.png` or `surface.png`) to your phone via AirDrop, email, or cloud storage.

--- a/vol_smile.py
+++ b/vol_smile.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Generate an FX volatility smile from standard market quotes.
+
+Inputs: ATM, 10/25-delta risk reversals and butterflies, forward, maturity,
+        rates, and delta convention.
+Outputs: 10Δ/25Δ strikes and vols plus a plotted smile.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+import matplotlib.pyplot as plt
+
+
+@dataclass(frozen=True)
+class MarketQuotes:
+    atm: float
+    rr_10: float
+    rr_25: float
+    bf_10: float
+    bf_25: float
+
+
+@dataclass(frozen=True)
+class MarketParams:
+    forward: float
+    maturity: float
+    rd: float
+    rf: float
+    delta_convention: str
+    premium_adjusted: bool
+
+
+def norm_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+# Acklam's approximation for inverse normal CDF.
+# Source: http://home.online.no/~pjacklam/notes/invnorm/
+# This is a standard, fast, and accurate approximation for most practical use.
+
+def norm_ppf(p: float) -> float:
+    if p <= 0.0 or p >= 1.0:
+        raise ValueError("p must be in (0, 1)")
+    a = [
+        -3.969683028665376e01,
+        2.209460984245205e02,
+        -2.759285104469687e02,
+        1.383577518672690e02,
+        -3.066479806614716e01,
+        2.506628277459239e00,
+    ]
+    b = [
+        -5.447609879822406e01,
+        1.615858368580409e02,
+        -1.556989798598866e02,
+        6.680131188771972e01,
+        -1.328068155288572e01,
+    ]
+    c = [
+        -7.784894002430293e-03,
+        -3.223964580411365e-01,
+        -2.400758277161838e00,
+        -2.549732539343734e00,
+        4.374664141464968e00,
+        2.938163982698783e00,
+    ]
+    d = [
+        7.784695709041462e-03,
+        3.224671290700398e-01,
+        2.445134137142996e00,
+        3.754408661907416e00,
+    ]
+    plow = 0.02425
+    phigh = 1 - plow
+    if p < plow:
+        q = math.sqrt(-2 * math.log(p))
+        return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / (
+            ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+        )
+    if p > phigh:
+        q = math.sqrt(-2 * math.log(1 - p))
+        return -(
+            (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5])
+            / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+        )
+    q = p - 0.5
+    r = q * q
+    return (
+        (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q
+        / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+    )
+
+
+def strike_from_delta(
+    delta: float,
+    is_call: bool,
+    vol: float,
+    params: MarketParams,
+) -> float:
+    sqrt_t = math.sqrt(params.maturity)
+    if params.delta_convention == "forward":
+        delta_adj = delta
+    elif params.delta_convention == "spot":
+        delta_adj = delta / math.exp(-params.rf * params.maturity)
+    else:
+        raise ValueError("delta_convention must be 'spot' or 'forward'")
+
+    if params.premium_adjusted:
+        # Premium-adjusted delta requires numerical solve; use simple iteration.
+        return solve_strike_premium_adjusted(delta, is_call, vol, params)
+
+    p = delta_adj if is_call else -delta_adj
+    if not 0.0 < p < 1.0:
+        raise ValueError("delta outside (0,1) after adjustment")
+    d1 = norm_ppf(p)
+    return params.forward * math.exp(-(d1 * vol * sqrt_t - 0.5 * vol * vol * params.maturity))
+
+
+def solve_strike_premium_adjusted(
+    delta: float,
+    is_call: bool,
+    vol: float,
+    params: MarketParams,
+) -> float:
+    sqrt_t = math.sqrt(params.maturity)
+    fwd = params.forward
+    discount_f = math.exp(-params.rf * params.maturity)
+
+    def delta_pa(k: float) -> float:
+        if k <= 0:
+            return 0.0
+        d1 = (math.log(fwd / k) + 0.5 * vol * vol * params.maturity) / (vol * sqrt_t)
+        d2 = d1 - vol * sqrt_t
+        if is_call:
+            return discount_f * (norm_cdf(d1) - (k / fwd) * norm_cdf(d2))
+        return -discount_f * (norm_cdf(-d1) - (k / fwd) * norm_cdf(-d2))
+
+    target = delta
+    # Use a bracket around forward for solve.
+    low, high = fwd * 0.2, fwd * 5.0
+    for _ in range(80):
+        mid = 0.5 * (low + high)
+        val = delta_pa(mid)
+        if is_call:
+            if val > target:
+                low = mid
+            else:
+                high = mid
+        else:
+            if val < -target:
+                low = mid
+            else:
+                high = mid
+    return 0.5 * (low + high)
+
+
+def build_vols(quotes: MarketQuotes) -> Tuple[float, float, float, float, float]:
+    vol_25c = quotes.atm + quotes.bf_25 + 0.5 * quotes.rr_25
+    vol_25p = quotes.atm + quotes.bf_25 - 0.5 * quotes.rr_25
+    vol_10c = quotes.atm + quotes.bf_10 + 0.5 * quotes.rr_10
+    vol_10p = quotes.atm + quotes.bf_10 - 0.5 * quotes.rr_10
+    return vol_10p, vol_25p, quotes.atm, vol_25c, vol_10c
+
+
+def build_strikes(
+    vols: Tuple[float, float, float, float, float],
+    params: MarketParams,
+) -> Tuple[float, float, float, float, float]:
+    vol_10p, vol_25p, atm, vol_25c, vol_10c = vols
+    k_10p = strike_from_delta(0.10, False, vol_10p, params)
+    k_25p = strike_from_delta(0.25, False, vol_25p, params)
+    k_atm = params.forward
+    k_25c = strike_from_delta(0.25, True, vol_25c, params)
+    k_10c = strike_from_delta(0.10, True, vol_10c, params)
+    return k_10p, k_25p, k_atm, k_25c, k_10c
+
+
+def interpolate_smile(strikes: Iterable[float], vols: Iterable[float]) -> Tuple[List[float], List[float]]:
+    points = sorted(zip(strikes, vols), key=lambda x: x[0])
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    grid = []
+    grid_vols = []
+    for i in range(len(xs) - 1):
+        x0, x1 = xs[i], xs[i + 1]
+        y0, y1 = ys[i], ys[i + 1]
+        steps = 20
+        for j in range(steps):
+            t = j / steps
+            grid.append(x0 + (x1 - x0) * t)
+            grid_vols.append(y0 + (y1 - y0) * t)
+    grid.append(xs[-1])
+    grid_vols.append(ys[-1])
+    return grid, grid_vols
+
+
+def plot_smile(strikes: Iterable[float], vols: Iterable[float], output: str) -> None:
+    grid_x, grid_y = interpolate_smile(strikes, vols)
+    plt.figure(figsize=(7, 4))
+    plt.plot(grid_x, grid_y, label="Interpolated smile")
+    plt.scatter(list(strikes), list(vols), color="red", label="Market quotes")
+    plt.xlabel("Strike")
+    plt.ylabel("Implied volatility")
+    plt.title("FX Volatility Smile")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output, dpi=200)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate an FX vol smile from RR/BF quotes.")
+    parser.add_argument("--atm", type=float, required=True, help="ATM volatility (decimal)")
+    parser.add_argument("--rr-10", type=float, required=True, help="10-delta risk reversal")
+    parser.add_argument("--rr-25", type=float, required=True, help="25-delta risk reversal")
+    parser.add_argument("--bf-10", type=float, required=True, help="10-delta butterfly")
+    parser.add_argument("--bf-25", type=float, required=True, help="25-delta butterfly")
+    parser.add_argument("--forward", type=float, required=True, help="Forward FX rate")
+    parser.add_argument("--maturity", type=float, required=True, help="Maturity in years")
+    parser.add_argument("--rd", type=float, required=True, help="Domestic rate")
+    parser.add_argument("--rf", type=float, required=True, help="Foreign rate")
+    parser.add_argument(
+        "--delta-convention",
+        choices=["spot", "forward"],
+        default="spot",
+        help="Delta convention",
+    )
+    parser.add_argument(
+        "--premium-adjusted",
+        action="store_true",
+        help="Use premium-adjusted delta",
+    )
+    parser.add_argument("--output", default="smile.png", help="Output image path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    quotes = MarketQuotes(
+        atm=args.atm,
+        rr_10=args.rr_10,
+        rr_25=args.rr_25,
+        bf_10=args.bf_10,
+        bf_25=args.bf_25,
+    )
+    params = MarketParams(
+        forward=args.forward,
+        maturity=args.maturity,
+        rd=args.rd,
+        rf=args.rf,
+        delta_convention=args.delta_convention,
+        premium_adjusted=args.premium_adjusted,
+    )
+    vols = build_vols(quotes)
+    strikes = build_strikes(vols, params)
+
+    labels = ["10Δ Put", "25Δ Put", "ATM", "25Δ Call", "10Δ Call"]
+    for label, strike, vol in zip(labels, strikes, vols):
+        print(f"{label}: strike={strike:.6f}, vol={vol:.4%}")
+
+    plot_smile(strikes, vols, args.output)
+    print(f"Saved smile plot to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vol_surface.py
+++ b/vol_surface.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Generate a 3D volatility surface from delta-based quotes."""
+from __future__ import annotations
+
+import argparse
+import math
+from typing import Iterable, List, Tuple
+
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+from vol_smile import MarketParams, strike_from_delta
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a 3D FX vol surface from delta quotes.")
+    parser.add_argument("--spot", type=float, required=True, help="Spot FX rate")
+    parser.add_argument("--maturity", type=float, required=True, help="Maturity in years")
+    parser.add_argument("--rd", type=float, required=True, help="Domestic rate")
+    parser.add_argument("--rf", type=float, required=True, help="Foreign rate")
+    parser.add_argument(
+        "--delta-convention",
+        choices=["spot", "forward"],
+        default="spot",
+        help="Delta convention",
+    )
+    parser.add_argument(
+        "--premium-adjusted",
+        action="store_true",
+        help="Use premium-adjusted delta",
+    )
+    parser.add_argument("--vol-50c", type=float, required=True, help="50-delta call vol")
+    parser.add_argument("--vol-50p", type=float, required=True, help="50-delta put vol")
+    parser.add_argument("--vol-25c", type=float, required=True, help="25-delta call vol")
+    parser.add_argument("--vol-25p", type=float, required=True, help="25-delta put vol")
+    parser.add_argument("--vol-10c", type=float, required=True, help="10-delta call vol")
+    parser.add_argument("--vol-10p", type=float, required=True, help="10-delta put vol")
+    parser.add_argument("--points", type=int, default=60, help="Number of delta points per wing")
+    parser.add_argument("--output", default="surface.png", help="Output image path")
+    return parser.parse_args()
+
+
+def linear_interpolate(x: float, xs: List[float], ys: List[float]) -> float:
+    if x <= xs[0]:
+        return ys[0]
+    if x >= xs[-1]:
+        return ys[-1]
+    for i in range(len(xs) - 1):
+        if xs[i] <= x <= xs[i + 1]:
+            t = (x - xs[i]) / (xs[i + 1] - xs[i])
+            return ys[i] + t * (ys[i + 1] - ys[i])
+    return ys[-1]
+
+
+def build_grid(
+    deltas: Iterable[float],
+    vols: Iterable[float],
+    params: MarketParams,
+) -> Tuple[List[float], List[float], List[float]]:
+    strike_grid: List[float] = []
+    delta_grid: List[float] = []
+    vol_grid: List[float] = []
+
+    for delta, vol in zip(deltas, vols):
+        is_call = delta > 0
+        strike = strike_from_delta(abs(delta), is_call, vol, params)
+        strike_grid.append(strike)
+        delta_grid.append(delta)
+        vol_grid.append(vol)
+    return delta_grid, strike_grid, vol_grid
+
+
+def plot_surface(
+    delta_grid: List[float],
+    strike_grid: List[float],
+    vol_grid: List[float],
+    output: str,
+) -> None:
+    fig = plt.figure(figsize=(8, 5))
+    ax = fig.add_subplot(111, projection="3d")
+    ax.plot_trisurf(delta_grid, strike_grid, vol_grid, cmap="viridis", linewidth=0.2)
+    ax.set_xlabel("Delta")
+    ax.set_ylabel("Strike")
+    ax.set_zlabel("Implied volatility")
+    ax.set_title("FX Volatility Surface (single maturity)")
+    plt.tight_layout()
+    plt.savefig(output, dpi=200)
+
+
+def main() -> None:
+    args = parse_args()
+    forward = args.spot * math.exp((args.rd - args.rf) * args.maturity)
+    params = MarketParams(
+        forward=forward,
+        maturity=args.maturity,
+        rd=args.rd,
+        rf=args.rf,
+        delta_convention=args.delta_convention,
+        premium_adjusted=args.premium_adjusted,
+    )
+
+    put_deltas = [-0.5, -0.25, -0.1]
+    put_vols = [args.vol_50p, args.vol_25p, args.vol_10p]
+    call_deltas = [0.1, 0.25, 0.5]
+    call_vols = [args.vol_10c, args.vol_25c, args.vol_50c]
+
+    print("Input quotes (delta, vol):")
+    for delta, vol in zip(put_deltas, put_vols):
+        print(f"{delta:+.2f}: {vol:.4%}")
+    for delta, vol in zip(call_deltas, call_vols):
+        print(f"{delta:+.2f}: {vol:.4%}")
+
+    puts = [
+        -0.5 + (0.4 * i / (args.points - 1))
+        for i in range(args.points)
+    ]
+    calls = [
+        0.1 + (0.4 * i / (args.points - 1))
+        for i in range(args.points)
+    ]
+
+    delta_values = puts + calls
+    vol_values = [
+        linear_interpolate(delta, put_deltas, put_vols) if delta < 0 else linear_interpolate(delta, call_deltas, call_vols)
+        for delta in delta_values
+    ]
+
+    delta_grid, strike_grid, vol_grid = build_grid(delta_values, vol_values, params)
+
+    print("\nComputed strikes (sample):")
+    for delta, strike, vol in zip(delta_grid[:: max(1, args.points // 5)], strike_grid[:: max(1, args.points // 5)], vol_grid[:: max(1, args.points // 5)]):
+        print(f"{delta:+.3f}: strike={strike:.6f}, vol={vol:.4%}")
+
+    plot_surface(delta_grid, strike_grid, vol_grid, args.output)
+    print(f"Saved surface plot to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a simple CLI to build and visualize a single-maturity 3D FX volatility surface from standard delta-based call/put quotes (50Δ/25Δ/10Δ) plus spot and rates.
- Make it easy to derive strikes from market deltas using the same delta conventions and premium-adjusted option used by the existing smile helper.

### Description
- Add `vol_surface.py`, a CLI that accepts `--spot`, `--maturity`, `--rd`, `--rf`, `--delta-convention`, `--premium-adjusted`, and delta vols via `--vol-50c/50p/25c/25p/10c/10p`, interpolates vols across deltas, derives strikes via `strike_from_delta`, and renders a 3D trisurf saved to PNG.
- Reuse `MarketParams` and `strike_from_delta` from `vol_smile.py` so the surface uses the same forward/spot and premium-adjusted conventions as the smile generator.
- Add README documentation and a usage example for the new `vol_surface.py` helper.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986ac670808832a87c21f12dd9b1f12)