### PR TITLE
Add commodity option volatility calculator (CLI and iPhone HTML) and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,28 @@ When complete, you'll be able to grab random quotes from the command line, like 
 ## Start the Tutorial
 
 You can find your next step in [this repo's issues](../../issues/)!
+
+## Commodity Option Volatility Calculator
+
+A new script `commodity_option_vol_calculator.py` is included for volatility calculations:
+
+- `hist` mode: annualized historical volatility from a price series.
+- `iv` mode: implied volatility for futures options using the Black-76 model.
+
+Examples:
+
+```bash
+python3 commodity_option_vol_calculator.py hist --prices "100,101,99.5,102" --annualization 252
+python3 commodity_option_vol_calculator.py iv --market-price 4.2 --futures-price 100 --strike 102 --time 0.25 --rate 0.03 --type call
+```
+
+## iPhone 使用方式（網頁版）
+
+新增 `iphone_option_vol_calculator.html`，可直接在 iPhone Safari 打開使用。
+
+- 方式 1：把檔案上傳到任意靜態空間（GitHub Pages / iCloud Drive）後用 Safari 開啟。
+- 方式 2：在電腦執行 `python3 -m http.server 8000`，iPhone 與電腦同網路下打開 `http://<電腦IP>:8000/iphone_option_vol_calculator.html`。
+
+此頁面包含：
+- 歷史波動率（價格序列）
+- Black-76 隱含波動率（期貨期權）

--- a/README.md
+++ b/README.md
@@ -40,3 +40,13 @@ python3 commodity_option_vol_calculator.py iv --market-price 4.2 --futures-price
 此頁面包含：
 - 歷史波動率（價格序列）
 - Black-76 隱含波動率（期貨期權）
+
+### 免參數互動模式（含中文檔名）
+
+若你直接執行：
+
+```bash
+python3 波動率計算器.py
+```
+
+程式會進入互動模式，不再因為缺少 `hist/iv` 參數而報錯。

--- a/commodity_option_vol_calculator.py
+++ b/commodity_option_vol_calculator.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Commodity option volatility calculator.
+
+Supports:
+1) Historical volatility from price series (log returns, annualized)
+2) Implied volatility from Black-76 option pricing (common for commodity futures options)
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from statistics import stdev
+
+
+def normal_cdf(x: float) -> float:
+    """Standard normal cumulative distribution function."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def black76_price(
+    futures_price: float,
+    strike: float,
+    time_to_expiry: float,
+    risk_free_rate: float,
+    volatility: float,
+    option_type: str,
+) -> float:
+    """Black-76 price for options on futures."""
+    if volatility <= 0 or time_to_expiry <= 0:
+        intrinsic = max(futures_price - strike, 0.0) if option_type == "call" else max(strike - futures_price, 0.0)
+        return math.exp(-risk_free_rate * time_to_expiry) * intrinsic
+
+    sigma_sqrt_t = volatility * math.sqrt(time_to_expiry)
+    d1 = (math.log(futures_price / strike) + 0.5 * volatility * volatility * time_to_expiry) / sigma_sqrt_t
+    d2 = d1 - sigma_sqrt_t
+    discount = math.exp(-risk_free_rate * time_to_expiry)
+
+    if option_type == "call":
+        return discount * (futures_price * normal_cdf(d1) - strike * normal_cdf(d2))
+    return discount * (strike * normal_cdf(-d2) - futures_price * normal_cdf(-d1))
+
+
+def implied_volatility_black76(
+    market_price: float,
+    futures_price: float,
+    strike: float,
+    time_to_expiry: float,
+    risk_free_rate: float,
+    option_type: str,
+    tolerance: float = 1e-8,
+    max_iterations: int = 200,
+) -> float:
+    """Solve implied volatility with bisection."""
+    low, high = 1e-6, 5.0
+    low_price = black76_price(futures_price, strike, time_to_expiry, risk_free_rate, low, option_type)
+    high_price = black76_price(futures_price, strike, time_to_expiry, risk_free_rate, high, option_type)
+
+    if not (low_price <= market_price <= high_price):
+        raise ValueError(
+            "Market price is outside model price bounds; check inputs."
+        )
+
+    for _ in range(max_iterations):
+        mid = 0.5 * (low + high)
+        mid_price = black76_price(futures_price, strike, time_to_expiry, risk_free_rate, mid, option_type)
+
+        if abs(mid_price - market_price) < tolerance:
+            return mid
+
+        if mid_price < market_price:
+            low = mid
+        else:
+            high = mid
+
+    return 0.5 * (low + high)
+
+
+def historical_volatility(prices: list[float], annualization_factor: int = 252) -> float:
+    """Annualized historical volatility from price series."""
+    if len(prices) < 2:
+        raise ValueError("Need at least two prices to compute volatility.")
+
+    returns = [math.log(prices[i] / prices[i - 1]) for i in range(1, len(prices))]
+    if len(returns) < 2:
+        raise ValueError("Need at least three prices for sample standard deviation.")
+
+    return stdev(returns) * math.sqrt(annualization_factor)
+
+
+def parse_prices(prices_text: str) -> list[float]:
+    return [float(item.strip()) for item in prices_text.split(",") if item.strip()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Commodity option volatility calculator")
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    hist = subparsers.add_parser("hist", help="Calculate historical volatility from prices")
+    hist.add_argument("--prices", required=True, help="Comma-separated prices, e.g. 102,101.5,103")
+    hist.add_argument("--annualization", type=int, default=252, help="Annualization factor, default 252")
+
+    iv = subparsers.add_parser("iv", help="Calculate implied volatility using Black-76")
+    iv.add_argument("--market-price", type=float, required=True, help="Observed option market price")
+    iv.add_argument("--futures-price", type=float, required=True, help="Current futures price")
+    iv.add_argument("--strike", type=float, required=True, help="Option strike")
+    iv.add_argument("--time", type=float, required=True, help="Time to expiry in years")
+    iv.add_argument("--rate", type=float, default=0.0, help="Risk-free rate (annualized, decimal)")
+    iv.add_argument("--type", choices=["call", "put"], required=True, help="Option type")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.mode == "hist":
+        prices = parse_prices(args.prices)
+        vol = historical_volatility(prices, args.annualization)
+        print(f"Historical Volatility: {vol:.6f} ({vol * 100:.2f}%)")
+        return
+
+    implied_vol = implied_volatility_black76(
+        market_price=args.market_price,
+        futures_price=args.futures_price,
+        strike=args.strike,
+        time_to_expiry=args.time,
+        risk_free_rate=args.rate,
+        option_type=args.type,
+    )
+    print(f"Implied Volatility (Black-76): {implied_vol:.6f} ({implied_vol * 100:.2f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/commodity_option_vol_calculator.py
+++ b/commodity_option_vol_calculator.py
@@ -94,7 +94,7 @@ def parse_prices(prices_text: str) -> list[float]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Commodity option volatility calculator")
-    subparsers = parser.add_subparsers(dest="mode", required=True)
+    subparsers = parser.add_subparsers(dest="mode")
 
     hist = subparsers.add_parser("hist", help="Calculate historical volatility from prices")
     hist.add_argument("--prices", required=True, help="Comma-separated prices, e.g. 102,101.5,103")
@@ -114,6 +114,35 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
+
+    if not args.mode:
+        print("請選擇模式: hist (歷史波動率) 或 iv (隱含波動率)")
+        mode = input("輸入模式 [hist/iv]: ").strip().lower()
+        if mode == "hist":
+            prices = parse_prices(input("輸入價格序列（逗號分隔）: "))
+            annual = input("輸入年化因子（預設252）: ").strip()
+            annualization = int(annual) if annual else 252
+            vol = historical_volatility(prices, annualization)
+            print(f"Historical Volatility: {vol:.6f} ({vol * 100:.2f}%)")
+            return
+        if mode == "iv":
+            market_price = float(input("輸入期權市價: "))
+            futures_price = float(input("輸入期貨價格: "))
+            strike = float(input("輸入履約價: "))
+            time_to_expiry = float(input("輸入到期時間（年）: "))
+            risk_free_rate = float(input("輸入無風險利率（例如0.03）: ") or "0")
+            option_type = input("輸入期權類型 [call/put]: ").strip().lower()
+            implied_vol = implied_volatility_black76(
+                market_price=market_price,
+                futures_price=futures_price,
+                strike=strike,
+                time_to_expiry=time_to_expiry,
+                risk_free_rate=risk_free_rate,
+                option_type=option_type,
+            )
+            print(f"Implied Volatility (Black-76): {implied_vol:.6f} ({implied_vol * 100:.2f}%)")
+            return
+        raise SystemExit("模式錯誤，請輸入 hist 或 iv。")
 
     if args.mode == "hist":
         prices = parse_prices(args.prices)

--- a/iphone_option_vol_calculator.html
+++ b/iphone_option_vol_calculator.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>商品期權波動率計算器</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif; margin: 0; background:#f4f6f8; color:#111; }
+    .wrap { max-width: 760px; margin: 0 auto; padding: 16px; }
+    .card { background:#fff; border-radius:14px; box-shadow: 0 2px 10px rgba(0,0,0,.08); padding:16px; margin-bottom:16px; }
+    h1 { font-size: 1.3rem; margin:0 0 12px; }
+    h2 { font-size: 1.05rem; margin: 0 0 10px; }
+    label { display:block; margin:10px 0 6px; font-weight:600; }
+    input, select, button, textarea { width:100%; box-sizing:border-box; font-size:16px; padding:10px; border:1px solid #d0d7de; border-radius:10px; }
+    button { background:#0a84ff; color:#fff; border:none; font-weight:700; margin-top:12px; }
+    .result { margin-top:12px; padding:10px; border-radius:10px; background:#f1f8ff; }
+    .muted { color:#666; font-size:.92rem; }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <div class="card">
+    <h1>商品期權波動率計算器（iPhone 版）</h1>
+    <p class="muted">可直接在 iPhone Safari 開啟（離線也可使用）。</p>
+  </div>
+
+  <div class="card">
+    <h2>歷史波動率</h2>
+    <label>價格序列（逗號分隔）</label>
+    <textarea id="hist-prices" rows="3">100,101,99.5,102</textarea>
+    <label>年化因子</label>
+    <input id="hist-annual" type="number" value="252" />
+    <button onclick="calcHist()">計算歷史波動率</button>
+    <div id="hist-result" class="result">尚未計算</div>
+  </div>
+
+  <div class="card">
+    <h2>隱含波動率（Black-76）</h2>
+    <label>期權市價</label><input id="iv-market" type="number" value="4.2" step="0.0001" />
+    <label>期貨價格</label><input id="iv-futures" type="number" value="100" step="0.0001" />
+    <label>履約價</label><input id="iv-strike" type="number" value="102" step="0.0001" />
+    <label>到期時間（年）</label><input id="iv-time" type="number" value="0.25" step="0.0001" />
+    <label>無風險利率（如 0.03）</label><input id="iv-rate" type="number" value="0.03" step="0.0001" />
+    <label>期權類型</label>
+    <select id="iv-type"><option value="call">Call</option><option value="put">Put</option></select>
+    <button onclick="calcIv()">計算隱含波動率</button>
+    <div id="iv-result" class="result">尚未計算</div>
+  </div>
+</div>
+
+<script>
+function normalCdf(x){ return 0.5 * (1 + erf(x / Math.sqrt(2))); }
+function erf(x){
+  const sign = x >= 0 ? 1 : -1;
+  x = Math.abs(x);
+  const a1=0.254829592,a2=-0.284496736,a3=1.421413741,a4=-1.453152027,a5=1.061405429,p=0.3275911;
+  const t = 1/(1+p*x);
+  const y = 1-(((((a5*t+a4)*t+a3)*t+a2)*t+a1)*t)*Math.exp(-x*x);
+  return sign*y;
+}
+function black76Price(F,K,T,r,sigma,type){
+  if (sigma <= 0 || T <= 0){
+    const intrinsic = type === 'call' ? Math.max(F-K,0) : Math.max(K-F,0);
+    return Math.exp(-r*T)*intrinsic;
+  }
+  const sigSqrtT = sigma*Math.sqrt(T);
+  const d1 = (Math.log(F/K)+0.5*sigma*sigma*T)/sigSqrtT;
+  const d2 = d1-sigSqrtT;
+  const disc = Math.exp(-r*T);
+  if (type === 'call') return disc*(F*normalCdf(d1)-K*normalCdf(d2));
+  return disc*(K*normalCdf(-d2)-F*normalCdf(-d1));
+}
+function impliedVol(market,F,K,T,r,type){
+  let low=1e-6,high=5;
+  const lowP=black76Price(F,K,T,r,low,type), highP=black76Price(F,K,T,r,high,type);
+  if (market < lowP || market > highP) throw new Error('市價超出模型可解範圍，請檢查輸入。');
+  for (let i=0;i<200;i++){
+    const mid=(low+high)/2;
+    const mp=black76Price(F,K,T,r,mid,type);
+    if (Math.abs(mp-market) < 1e-8) return mid;
+    if (mp < market) low = mid; else high = mid;
+  }
+  return (low+high)/2;
+}
+function calcHist(){
+  try{
+    const prices = document.getElementById('hist-prices').value.split(',').map(s=>parseFloat(s.trim())).filter(Number.isFinite);
+    if (prices.length < 3) throw new Error('請至少輸入 3 個價格。');
+    const annual = parseFloat(document.getElementById('hist-annual').value);
+    const rets=[];
+    for (let i=1;i<prices.length;i++) rets.push(Math.log(prices[i]/prices[i-1]));
+    const mean = rets.reduce((a,b)=>a+b,0)/rets.length;
+    const varSample = rets.reduce((a,b)=>a+(b-mean)*(b-mean),0)/(rets.length-1);
+    const vol = Math.sqrt(varSample)*Math.sqrt(annual);
+    document.getElementById('hist-result').textContent = `歷史波動率：${vol.toFixed(6)} (${(vol*100).toFixed(2)}%)`;
+  }catch(e){ document.getElementById('hist-result').textContent = `錯誤：${e.message}`; }
+}
+function calcIv(){
+  try{
+    const market=parseFloat(document.getElementById('iv-market').value);
+    const F=parseFloat(document.getElementById('iv-futures').value);
+    const K=parseFloat(document.getElementById('iv-strike').value);
+    const T=parseFloat(document.getElementById('iv-time').value);
+    const r=parseFloat(document.getElementById('iv-rate').value);
+    const type=document.getElementById('iv-type').value;
+    const iv=impliedVol(market,F,K,T,r,type);
+    document.getElementById('iv-result').textContent = `隱含波動率：${iv.toFixed(6)} (${(iv*100).toFixed(2)}%)`;
+  }catch(e){ document.getElementById('iv-result').textContent = `錯誤：${e.message}`; }
+}
+</script>
+</body>
+</html>

--- a/波動率計算器.py
+++ b/波動率計算器.py
@@ -1,0 +1,4 @@
+from commodity_option_vol_calculator import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a simple CLI utility to compute historical volatility and Black-76 implied volatility for commodity futures options. 
- Offer an offline-friendly iPhone web UI so the calculator can be used directly in Safari on mobile devices. 
- Document the new tools and usage examples in the repository `README.md`.

### Description
- Add `commodity_option_vol_calculator.py` implementing `historical_volatility`, `black76_price`, and `implied_volatility_black76` with a CLI built via `argparse` and helper `parse_prices` for CSV price input. 
- Implement Black-76 pricing and a bisection solver for implied volatility, and provide a `hist` mode that computes annualized historical volatility from log returns. 
- Add `iphone_option_vol_calculator.html` containing a small JavaScript implementation of the same calculations and a mobile-optimized UI for offline use. 
- Update `README.md` with usage examples for the CLI and instructions for opening the iPhone HTML page.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031f7afd48832aabdfba4958d6b562)